### PR TITLE
Add a modified alert_rules plugin to add back namespaced alerts

### DIFF
--- a/plugins/namespaced_alert_rules/v1/plugin.go
+++ b/plugins/namespaced_alert_rules/v1/plugin.go
@@ -1,0 +1,156 @@
+package plugin
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"text/template"
+
+	"github.com/prometheus/prometheus/model/rulefmt"
+
+	"github.com/slok/sloth/pkg/common/conventions"
+	"github.com/slok/sloth/pkg/common/model"
+	utilsdata "github.com/slok/sloth/pkg/common/utils/data"
+	promutils "github.com/slok/sloth/pkg/common/utils/prometheus"
+	pluginslov1 "github.com/slok/sloth/pkg/prometheus/plugin/slo/v1"
+)
+
+const (
+	PluginVersion = "prometheus/slo/v1"
+	PluginID      = "mongodb.org/core_mod/namespaced_alert_rules/v1"
+)
+
+type Config struct {
+	Namespace string            `json:"namespace,omitempty"`
+}
+
+func NewPlugin(configData json.RawMessage, _ pluginslov1.AppUtils) (pluginslov1.Plugin, error) {
+	config := Config{}
+	err := json.Unmarshal(configData, &config)
+	if err != nil {
+		return nil, fmt.Errorf("invalid config: %w", err)
+	}
+
+	if config.Namespace == "" {
+		return nil, fmt.Errorf("namespace is required")
+	}
+
+	return plugin{config: config}, nil
+}
+
+type plugin struct {
+	config Config
+}
+
+func (p plugin) ProcessSLO(ctx context.Context, request *pluginslov1.Request, result *pluginslov1.Result) error {
+	rules, err := p.generateSLOAlertRules(ctx, request.SLO, request.MWMBAlertGroup)
+	if err != nil {
+		return err
+	}
+
+	result.SLORules.AlertRules.Rules = rules
+
+	return nil
+}
+
+func (p plugin) generateSLOAlertRules(ctx context.Context, slo model.PromSLO, alerts model.MWMBAlertGroup) ([]rulefmt.Rule, error) {
+	rules := []rulefmt.Rule{}
+
+	// Generate Page alerts.
+	if !slo.PageAlertMeta.Disable {
+		rule, err := p.defaultSLOAlertGenerator(slo, slo.PageAlertMeta, alerts.PageQuick, alerts.PageSlow)
+		if err != nil {
+			return nil, fmt.Errorf("could not create page alert: %w", err)
+		}
+
+		rules = append(rules, *rule)
+	}
+
+	// Generate Ticket alerts.
+	if !slo.TicketAlertMeta.Disable {
+		rule, err := p.defaultSLOAlertGenerator(slo, slo.TicketAlertMeta, alerts.TicketQuick, alerts.TicketSlow)
+		if err != nil {
+			return nil, fmt.Errorf("could not create ticket alert: %w", err)
+		}
+
+		rules = append(rules, *rule)
+	}
+
+	return rules, nil
+}
+
+func (p plugin) defaultSLOAlertGenerator(slo model.PromSLO, sloAlert model.PromAlertMeta, quick, slow model.MWMBAlert) (*rulefmt.Rule, error) {
+	// Generate the filter labels based on the SLO ids.
+	filterLabels := conventions.GetSLOIDPromLabels(slo)
+
+	// Add the namespace
+	filterLabels["namespace"] = p.config.Namespace
+	metricFilter := promutils.LabelsToPromFilter(filterLabels)
+
+	// Render the alert template.
+	tplData := struct {
+		MetricFilter         string
+		ErrorBudgetRatio     float64
+		QuickShortMetric     string
+		QuickShortBurnFactor float64
+		QuickLongMetric      string
+		QuickLongBurnFactor  float64
+		SlowShortMetric      string
+		SlowShortBurnFactor  float64
+		SlowQuickMetric      string
+		SlowQuickBurnFactor  float64
+		WindowLabel          string
+	}{
+		MetricFilter:         metricFilter,
+		ErrorBudgetRatio:     quick.ErrorBudget / 100, // Any(quick or slow) should work because are the same.
+		QuickShortMetric:     conventions.GetSLIErrorMetric(quick.ShortWindow),
+		QuickShortBurnFactor: quick.BurnRateFactor,
+		QuickLongMetric:      conventions.GetSLIErrorMetric(quick.LongWindow),
+		QuickLongBurnFactor:  quick.BurnRateFactor,
+		SlowShortMetric:      conventions.GetSLIErrorMetric(slow.ShortWindow),
+		SlowShortBurnFactor:  slow.BurnRateFactor,
+		SlowQuickMetric:      conventions.GetSLIErrorMetric(slow.LongWindow),
+		SlowQuickBurnFactor:  slow.BurnRateFactor,
+		WindowLabel:          conventions.PromSLOWindowLabelName,
+	}
+	var expr bytes.Buffer
+	err := mwmbAlertTpl.Execute(&expr, tplData)
+	if err != nil {
+		return nil, fmt.Errorf("could not render alert expression: %w", err)
+	}
+
+	// Add specific annotations.
+	severity := quick.Severity.String() // Any(quick or slow) should work because are the same.
+	extraAnnotations := map[string]string{
+		"title":   fmt.Sprintf("(%s) {{$labels.%s}} {{$labels.%s}} SLO error budget burn rate is too fast.", severity, conventions.PromSLOServiceLabelName, conventions.PromSLONameLabelName),
+		"summary": fmt.Sprintf("{{$labels.%s}} {{$labels.%s}} SLO error budget burn rate is over expected.", conventions.PromSLOServiceLabelName, conventions.PromSLONameLabelName),
+	}
+
+	// Add specific labels. We don't add the labels from the rules because we will
+	// inherit on the alerts, this way we avoid warnings of overrided labels.
+	extraLabels := map[string]string{
+		conventions.PromSLOSeverityLabelName: severity,
+	}
+
+	return &rulefmt.Rule{
+		Alert:       sloAlert.Name,
+		Expr:        expr.String(),
+		Annotations: utilsdata.MergeLabels(extraAnnotations, sloAlert.Annotations),
+		Labels:      utilsdata.MergeLabels(extraLabels, sloAlert.Labels),
+	}, nil
+}
+
+// Multiburn multiwindow alert template.
+var mwmbAlertTpl = template.Must(template.New("mwmbAlertTpl").Option("missingkey=error").Parse(`(
+    max({{ .QuickShortMetric }}{{ .MetricFilter}} > ({{ .QuickShortBurnFactor }} * {{ .ErrorBudgetRatio }})) without ({{ .WindowLabel }})
+    and
+    max({{ .QuickLongMetric }}{{ .MetricFilter}} > ({{ .QuickLongBurnFactor }} * {{ .ErrorBudgetRatio }})) without ({{ .WindowLabel }})
+)
+or
+(
+    max({{ .SlowShortMetric }}{{ .MetricFilter }} > ({{ .SlowShortBurnFactor }} * {{ .ErrorBudgetRatio }})) without ({{ .WindowLabel }})
+    and
+    max({{ .SlowQuickMetric }}{{ .MetricFilter }} > ({{ .SlowQuickBurnFactor }} * {{ .ErrorBudgetRatio }})) without ({{ .WindowLabel }})
+)
+`))

--- a/plugins/namespaced_alert_rules/v1/plugin_test.go
+++ b/plugins/namespaced_alert_rules/v1/plugin_test.go
@@ -1,0 +1,293 @@
+package plugin_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/model/rulefmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	plugin "github.com/slok/sloth-common-sli-plugins/plugins/namespaced_alert_rules/v1"
+	"github.com/slok/sloth/pkg/common/model"
+	pluginslov1 "github.com/slok/sloth/pkg/prometheus/plugin/slo/v1"
+	pluginslov1testing "github.com/slok/sloth/pkg/prometheus/plugin/slo/v1/testing"
+)
+
+func MustJSONRawMessage(t *testing.T, v any) json.RawMessage {
+	j, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("failed to marshal %T: %v", v, err)
+	}
+	return j
+}
+
+func baseSLOAlertGroup() model.MWMBAlertGroup {
+	return model.MWMBAlertGroup{
+		PageQuick: model.MWMBAlert{
+			ID:             "10",
+			ShortWindow:    11 * time.Minute,
+			LongWindow:     12 * time.Minute,
+			BurnRateFactor: 13,
+			ErrorBudget:    1,
+			Severity:       model.PageAlertSeverity,
+		},
+		PageSlow: model.MWMBAlert{
+			ID:             "20",
+			ShortWindow:    21 * time.Minute,
+			LongWindow:     22 * time.Minute,
+			BurnRateFactor: 23,
+			ErrorBudget:    1,
+			Severity:       model.PageAlertSeverity,
+		},
+		TicketQuick: model.MWMBAlert{
+			ID:             "30",
+			ShortWindow:    31 * time.Minute,
+			LongWindow:     32 * time.Minute,
+			BurnRateFactor: 33,
+			ErrorBudget:    1,
+			Severity:       model.TicketAlertSeverity,
+		},
+		TicketSlow: model.MWMBAlert{
+			ID:             "4",
+			ShortWindow:    41 * time.Minute,
+			LongWindow:     42 * time.Minute,
+			BurnRateFactor: 43,
+			ErrorBudget:    1,
+			Severity:       model.TicketAlertSeverity,
+		},
+	}
+}
+
+func baseSLO() model.PromSLO {
+	return model.PromSLO{
+		ID:      "test-svc-test",
+		Name:    "test",
+		Service: "test-svc",
+		PageAlertMeta: model.PromAlertMeta{
+			Name:        "something1",
+			Labels:      map[string]string{"custom-label": "test1"},
+			Annotations: map[string]string{"custom-annot": "test1"},
+		},
+		TicketAlertMeta: model.PromAlertMeta{
+			Name:        "something2",
+			Labels:      map[string]string{"custom-label": "test2"},
+			Annotations: map[string]string{"custom-annot": "test2"},
+		},
+	}
+}
+
+func TestPlugin(t *testing.T) {
+	tests := map[string]struct {
+		slo        model.PromSLO
+		alertGroup func() model.MWMBAlertGroup
+		expRules   []rulefmt.Rule
+		expErr     bool
+	}{
+		"Having and SLO an its page and ticket alerts should create the recording rules.": {
+			slo:        baseSLO(),
+			alertGroup: baseSLOAlertGroup,
+			expRules: []rulefmt.Rule{
+				{
+					Alert: "something1",
+					Expr: `(
+    max(slo:sli_error:ratio_rate11m{namespace="test-ns", sloth_id="test-svc-test", sloth_service="test-svc", sloth_slo="test"} > (13 * 0.01)) without (sloth_window)
+    and
+    max(slo:sli_error:ratio_rate12m{namespace="test-ns", sloth_id="test-svc-test", sloth_service="test-svc", sloth_slo="test"} > (13 * 0.01)) without (sloth_window)
+)
+or
+(
+    max(slo:sli_error:ratio_rate21m{namespace="test-ns", sloth_id="test-svc-test", sloth_service="test-svc", sloth_slo="test"} > (23 * 0.01)) without (sloth_window)
+    and
+    max(slo:sli_error:ratio_rate22m{namespace="test-ns", sloth_id="test-svc-test", sloth_service="test-svc", sloth_slo="test"} > (23 * 0.01)) without (sloth_window)
+)
+`,
+					Labels: map[string]string{
+						"custom-label":   "test1",
+						"sloth_severity": "page",
+					},
+					Annotations: map[string]string{
+						"custom-annot": "test1",
+						"summary":      "{{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn rate is over expected.",
+						"title":        "(page) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn rate is too fast.",
+					},
+				},
+				{
+					Alert: "something2",
+					Expr: `(
+    max(slo:sli_error:ratio_rate31m{namespace="test-ns", sloth_id="test-svc-test", sloth_service="test-svc", sloth_slo="test"} > (33 * 0.01)) without (sloth_window)
+    and
+    max(slo:sli_error:ratio_rate32m{namespace="test-ns", sloth_id="test-svc-test", sloth_service="test-svc", sloth_slo="test"} > (33 * 0.01)) without (sloth_window)
+)
+or
+(
+    max(slo:sli_error:ratio_rate41m{namespace="test-ns", sloth_id="test-svc-test", sloth_service="test-svc", sloth_slo="test"} > (43 * 0.01)) without (sloth_window)
+    and
+    max(slo:sli_error:ratio_rate42m{namespace="test-ns", sloth_id="test-svc-test", sloth_service="test-svc", sloth_slo="test"} > (43 * 0.01)) without (sloth_window)
+)
+`,
+					Labels: map[string]string{
+						"custom-label":   "test2",
+						"sloth_severity": "ticket",
+					},
+					Annotations: map[string]string{
+						"custom-annot": "test2",
+						"summary":      "{{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn rate is over expected.",
+						"title":        "(ticket) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn rate is too fast.",
+					},
+				},
+			},
+		},
+
+		"Having and SLO an page and disabled ticket alerts should only create only page alert rules.": {
+			slo: model.PromSLO{
+				ID:      "test-svc-test",
+				Name:    "test",
+				Service: "test-svc",
+				PageAlertMeta: model.PromAlertMeta{
+					Name:        "something1",
+					Labels:      map[string]string{"custom-label": "test1"},
+					Annotations: map[string]string{"custom-annot": "test1"},
+				},
+				TicketAlertMeta: model.PromAlertMeta{
+					Disable: true,
+				},
+			},
+			alertGroup: baseSLOAlertGroup,
+			expRules: []rulefmt.Rule{
+				{
+					Alert: "something1",
+					Expr: `(
+    max(slo:sli_error:ratio_rate11m{namespace="test-ns", sloth_id="test-svc-test", sloth_service="test-svc", sloth_slo="test"} > (13 * 0.01)) without (sloth_window)
+    and
+    max(slo:sli_error:ratio_rate12m{namespace="test-ns", sloth_id="test-svc-test", sloth_service="test-svc", sloth_slo="test"} > (13 * 0.01)) without (sloth_window)
+)
+or
+(
+    max(slo:sli_error:ratio_rate21m{namespace="test-ns", sloth_id="test-svc-test", sloth_service="test-svc", sloth_slo="test"} > (23 * 0.01)) without (sloth_window)
+    and
+    max(slo:sli_error:ratio_rate22m{namespace="test-ns", sloth_id="test-svc-test", sloth_service="test-svc", sloth_slo="test"} > (23 * 0.01)) without (sloth_window)
+)
+`,
+					Labels: map[string]string{
+						"custom-label":   "test1",
+						"sloth_severity": "page",
+					},
+					Annotations: map[string]string{
+						"custom-annot": "test1",
+						"summary":      "{{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn rate is over expected.",
+						"title":        "(page) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn rate is too fast.",
+					},
+				},
+			},
+		},
+		"Having and SLO an ticker and page alerts disabled should only create ticket alert rules.": {
+			slo: model.PromSLO{
+				ID:      "test-svc-test",
+				Name:    "test",
+				Service: "test-svc",
+				PageAlertMeta: model.PromAlertMeta{
+					Disable: true,
+				},
+				TicketAlertMeta: model.PromAlertMeta{
+					Name:        "something2",
+					Labels:      map[string]string{"custom-label": "test2"},
+					Annotations: map[string]string{"custom-annot": "test2"},
+				},
+			},
+			alertGroup: baseSLOAlertGroup,
+			expRules: []rulefmt.Rule{
+				{
+					Alert: "something2",
+					Expr: `(
+    max(slo:sli_error:ratio_rate31m{namespace="test-ns", sloth_id="test-svc-test", sloth_service="test-svc", sloth_slo="test"} > (33 * 0.01)) without (sloth_window)
+    and
+    max(slo:sli_error:ratio_rate32m{namespace="test-ns", sloth_id="test-svc-test", sloth_service="test-svc", sloth_slo="test"} > (33 * 0.01)) without (sloth_window)
+)
+or
+(
+    max(slo:sli_error:ratio_rate41m{namespace="test-ns", sloth_id="test-svc-test", sloth_service="test-svc", sloth_slo="test"} > (43 * 0.01)) without (sloth_window)
+    and
+    max(slo:sli_error:ratio_rate42m{namespace="test-ns", sloth_id="test-svc-test", sloth_service="test-svc", sloth_slo="test"} > (43 * 0.01)) without (sloth_window)
+)
+`,
+					Labels: map[string]string{
+						"custom-label":   "test2",
+						"sloth_severity": "ticket",
+					},
+					Annotations: map[string]string{
+						"custom-annot": "test2",
+						"summary":      "{{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn rate is over expected.",
+						"title":        "(ticket) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn rate is too fast.",
+					},
+				},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+
+			// Load plugin
+			plugin, err := pluginslov1testing.NewTestPlugin(
+				t.Context(),
+				pluginslov1testing.TestPluginConfig{PluginConfiguration: MustJSONRawMessage(t, plugin.Config{Namespace: "test-ns"})},
+			)
+			require.NoError(err)
+
+			// Execute plugin.
+			req := pluginslov1.Request{
+				SLO:            test.slo,
+				MWMBAlertGroup: test.alertGroup(),
+			}
+			res := pluginslov1.Result{}
+			err = plugin.ProcessSLO(t.Context(), &req, &res)
+
+			// Check result.
+			if test.expErr {
+				assert.Error(err)
+			} else if assert.NoError(err) {
+				assert.Equal(test.expRules, res.SLORules.AlertRules.Rules)
+			}
+		})
+	}
+}
+
+func BenchmarkPluginYaegi(b *testing.B) {
+	plugin, err := pluginslov1testing.NewTestPlugin(b.Context(), pluginslov1testing.TestPluginConfig{})
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	req := &pluginslov1.Request{
+		SLO:            baseSLO(),
+		MWMBAlertGroup: baseSLOAlertGroup(),
+	}
+	for b.Loop() {
+		err = plugin.ProcessSLO(b.Context(), req, &pluginslov1.Result{})
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkPluginGo(b *testing.B) {
+	plugin, err := plugin.NewPlugin([]byte(`{"namespace":"test-ns""}`), pluginslov1.AppUtils{})
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	req := &pluginslov1.Request{
+		SLO:            baseSLO(),
+		MWMBAlertGroup: baseSLOAlertGroup(),
+	}
+	for b.Loop() {
+		err = plugin.ProcessSLO(b.Context(), req, &pluginslov1.Result{})
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
Without this, we are getting alerts for all namespaces in kubernetes. Simple fix to filter by namespace which we can do in helm.

Signed-off-by: James M Leddy <james.leddy@mongodb.com>