### PR TITLE
Update metadata_rules to propagate groupByLabels via group_left join

### DIFF
--- a/plugins/metadata_rules/v1/plugin.go
+++ b/plugins/metadata_rules/v1/plugin.go
@@ -55,13 +55,13 @@ func (p plugin) generateMetadataRecordingRules(ctx context.Context, info model.I
 
 	// Metatada Recordings.
 	const (
-		metricSLOObjectiveRatio                  = "slo:objective:ratio"
-		metricSLOErrorBudgetRatio                = "slo:error_budget:ratio"
-		metricSLOTimePeriodDays                  = "slo:time_period:days"
 		metricSLOCurrentBurnRateRatio            = "slo:current_burn_rate:ratio"
 		metricSLOPeriodBurnRateRatio             = "slo:period_burn_rate:ratio"
 		metricSLOPeriodErrorBudgetRemainingRatio = "slo:period_error_budget_remaining:ratio"
 		metricSLOInfo                            = "sloth_slo_info"
+		metricSLOObjectiveRatio                  = "slo:objective:ratio"
+		metricSLOErrorBudgetRatio                = "slo:error_budget:ratio"
+		metricSLOTimePeriodDays                  = "slo:time_period:days"
 	)
 
 	sloObjectiveRatio := slo.Objective / 100
@@ -71,11 +71,11 @@ func (p plugin) generateMetadataRecordingRules(ctx context.Context, info model.I
 	// allow us to group by labels we don't filter on (eg. exported region differs from metric region)
 	groupLabels := make(map[string]string, len(p.config.GroupByLabels))
 	for _, label := range p.config.GroupByLabels {
-		groupLabels[label] = ""
-
+		if _, ok := labels[label]; !ok {
+			groupLabels[label] = ""
+		}
 	}
-	groupLabels = utilsdata.MergeLabels(groupLabels, labels)
-	sloGroup := labelsToPromGroup(groupLabels)
+	sloGroup := labelsToPromGroup(utilsdata.MergeLabels(groupLabels, labels))
 
 	var currentBurnRateExpr bytes.Buffer
 	err := burnRateRecordingExprTpl.Execute(&currentBurnRateExpr, map[string]string{
@@ -99,28 +99,39 @@ func (p plugin) generateMetadataRecordingRules(ctx context.Context, info model.I
 		return nil, fmt.Errorf("could not render period burn rate prometheus metadata recording rule expression: %w", err)
 	}
 
+	burnRateGroupLeft := ""
+	infoGroupLeft := ""
+
+	if len(groupLabels) > 0 {
+		sloMinimalGroup := labelsToPromGroup(groupLabels)
+
+		// We must derive the group labels from the prior burn rate rule and group left to the vectors below
+		var currentBurnRateLabels bytes.Buffer
+		err = labelGroupRecordingExprTpl.Execute(&currentBurnRateLabels, map[string]string{
+			"BurnRateMetric": metricSLOCurrentBurnRateRatio,
+			"MetricFilter":   sloFilter,
+			"SLOGroup":       sloMinimalGroup,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("could not render group labels from current burn rate for prometheus metadata recording rule expression: %w", err)
+		}
+		burnRateGroupLeft = currentBurnRateLabels.String()
+
+		// Makes slightly more sense to use the info label where we have it
+		var infoLabels bytes.Buffer
+		err = labelGroupRecordingExprTpl.Execute(&infoLabels, map[string]string{
+			"BurnRateMetric": metricSLOInfo,
+			"MetricFilter":   sloFilter,
+			"SLOGroup":       sloMinimalGroup,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("could not render group labels from slo info metric for prometheus metadata recording rule expression: %w", err)
+		}
+		infoGroupLeft = infoLabels.String()
+	}
+
+	// Order for group labels. Burn rate and info come first so we can use them later to get label values
 	rules := []rulefmt.Rule{
-		// SLO Objective.
-		{
-			Record: metricSLOObjectiveRatio,
-			Expr:   fmt.Sprintf(`vector(%g)`, sloObjectiveRatio),
-			Labels: labels,
-		},
-
-		// Error budget.
-		{
-			Record: metricSLOErrorBudgetRatio,
-			Expr:   fmt.Sprintf(`vector(1-%g)`, sloObjectiveRatio),
-			Labels: labels,
-		},
-
-		// Total period.
-		{
-			Record: metricSLOTimePeriodDays,
-			Expr:   fmt.Sprintf(`vector(%g)`, slo.TimeWindow.Hours()/24),
-			Labels: labels,
-		},
-
 		// Current burning speed.
 		{
 			Record: metricSLOCurrentBurnRateRatio,
@@ -145,7 +156,7 @@ func (p plugin) generateMetadataRecordingRules(ctx context.Context, info model.I
 		// Info.
 		{
 			Record: metricSLOInfo,
-			Expr:   `vector(1)`,
+			Expr:   fmt.Sprintf(`vector(1)%s`, burnRateGroupLeft),
 			Labels: utilsdata.MergeLabels(labels, map[string]string{
 				conventions.PromSLOVersionLabelName:   info.Version,
 				conventions.PromSLOModeLabelName:      string(info.Mode),
@@ -153,6 +164,33 @@ func (p plugin) generateMetadataRecordingRules(ctx context.Context, info model.I
 				conventions.PromSLOObjectiveLabelName: strconv.FormatFloat(slo.Objective, 'f', -1, 64),
 			}),
 		},
+
+		// SLO Objective.
+		{
+			Record: metricSLOObjectiveRatio,
+			Expr:   fmt.Sprintf(`vector(%g)%s`, sloObjectiveRatio, infoGroupLeft),
+			Labels: labels,
+		},
+
+		// Error budget.
+		{
+			Record: metricSLOErrorBudgetRatio,
+			Expr:   fmt.Sprintf(`vector(1-%g)%s`, sloObjectiveRatio, infoGroupLeft),
+			Labels: labels,
+		},
+
+		// Total period.
+		{
+			Record: metricSLOTimePeriodDays,
+			Expr:   fmt.Sprintf(`vector(%g)%s`, slo.TimeWindow.Hours()/24, infoGroupLeft),
+			Labels: labels,
+		},
+	}
+
+	// If not grouping, reorder to the original order to avoid PrometheusRule resource churn
+	if len(groupLabels) == 0 {
+		origRules := []rulefmt.Rule{rules[4], rules[5], rules[6], rules[0], rules[1], rules[2], rules[3]}
+		rules = origRules
 	}
 
 	return rules, nil
@@ -173,3 +211,6 @@ var burnRateRecordingExprTpl = template.Must(template.New("burnRateExpr").Option
 / on({{ .SLOGroup }}) group_left
 {{ .ErrorBudgetRatioMetric }}{{ .MetricFilter }}
 `))
+
+var labelGroupRecordingExprTpl = template.Must(template.New("labelGroupExpr").Option("missingkey=error").Parse(` * group({{ .BurnRateMetric }}{{ .MetricFilter }})
+by ({{ .SLOGroup }})`))

--- a/plugins/metadata_rules/v1/plugin_test.go
+++ b/plugins/metadata_rules/v1/plugin_test.go
@@ -66,95 +66,6 @@ func TestPlugin(t *testing.T) {
 		expRules     []rulefmt.Rule
 		expErr       bool
 	}{
-		"groupByLabels config should add extra labels to on() clause with empty value.": {
-			pluginConfig: json.RawMessage(`{"groupByLabels":["namespace"]}`),
-			info:         baseInfo(),
-			slo:          baseSLO(),
-			alertGroup:   baseAlertGroup(),
-			expRules: []rulefmt.Rule{
-				{
-					Record: "slo:objective:ratio",
-					Expr:   "vector(0.9990000000000001)",
-					Labels: map[string]string{
-						"kind":          "test",
-						"sloth_service": "test-svc",
-						"sloth_slo":     "test-name",
-						"sloth_id":      "test",
-					},
-				},
-				{
-					Record: "slo:error_budget:ratio",
-					Expr:   "vector(1-0.9990000000000001)",
-					Labels: map[string]string{
-						"kind":          "test",
-						"sloth_service": "test-svc",
-						"sloth_slo":     "test-name",
-						"sloth_id":      "test",
-					},
-				},
-				{
-					Record: "slo:time_period:days",
-					Expr:   "vector(30)",
-					Labels: map[string]string{
-						"kind":          "test",
-						"sloth_service": "test-svc",
-						"sloth_slo":     "test-name",
-						"sloth_id":      "test",
-					},
-				},
-				{
-					Record: "slo:current_burn_rate:ratio",
-					Expr: `slo:sli_error:ratio_rate5m{kind="test", sloth_id="test", sloth_service="test-svc", sloth_slo="test-name"}
-/ on(kind, namespace, sloth_id, sloth_service, sloth_slo) group_left
-slo:error_budget:ratio{kind="test", sloth_id="test", sloth_service="test-svc", sloth_slo="test-name"}
-`,
-					Labels: map[string]string{
-						"kind":          "test",
-						"sloth_service": "test-svc",
-						"sloth_slo":     "test-name",
-						"sloth_id":      "test",
-					},
-				},
-				{
-					Record: "slo:period_burn_rate:ratio",
-					Expr: `slo:sli_error:ratio_rate30d{kind="test", sloth_id="test", sloth_service="test-svc", sloth_slo="test-name"}
-/ on(kind, namespace, sloth_id, sloth_service, sloth_slo) group_left
-slo:error_budget:ratio{kind="test", sloth_id="test", sloth_service="test-svc", sloth_slo="test-name"}
-`,
-					Labels: map[string]string{
-						"kind":          "test",
-						"sloth_service": "test-svc",
-						"sloth_slo":     "test-name",
-						"sloth_id":      "test",
-					},
-				},
-				{
-					Record: "slo:period_error_budget_remaining:ratio",
-					Expr:   `1 - slo:period_burn_rate:ratio{kind="test", sloth_id="test", sloth_service="test-svc", sloth_slo="test-name"}`,
-					Labels: map[string]string{
-						"kind":          "test",
-						"sloth_service": "test-svc",
-						"sloth_slo":     "test-name",
-						"sloth_id":      "test",
-					},
-				},
-				{
-					Record: "sloth_slo_info",
-					Expr:   `vector(1)`,
-					Labels: map[string]string{
-						"kind":            "test",
-						"sloth_service":   "test-svc",
-						"sloth_slo":       "test-name",
-						"sloth_id":        "test",
-						"sloth_version":   "test-ver",
-						"sloth_mode":      "test",
-						"sloth_spec":      "test/v1",
-						"sloth_objective": "99.9",
-					},
-				},
-			},
-		},
-
 		"Having and SLO an its mwmb alerts should create the metadata recording rules.": {
 			info:       baseInfo(),
 			slo:        baseSLO(),
@@ -238,6 +149,99 @@ slo:error_budget:ratio{kind="test", sloth_id="test", sloth_service="test-svc", s
 						"sloth_mode":      "test",
 						"sloth_spec":      "test/v1",
 						"sloth_objective": "99.9",
+					},
+				},
+			},
+		},
+
+		"groupByLabels config should add extra labels to on() clause with empty value.": {
+			pluginConfig: json.RawMessage(`{"groupByLabels":["namespace"]}`),
+			info:         baseInfo(),
+			slo:          baseSLO(),
+			alertGroup:   baseAlertGroup(),
+			expRules: []rulefmt.Rule{
+				{
+					Record: "slo:current_burn_rate:ratio",
+					Expr: `slo:sli_error:ratio_rate5m{kind="test", sloth_id="test", sloth_service="test-svc", sloth_slo="test-name"}
+/ on(kind, namespace, sloth_id, sloth_service, sloth_slo) group_left
+slo:error_budget:ratio{kind="test", sloth_id="test", sloth_service="test-svc", sloth_slo="test-name"}
+`,
+					Labels: map[string]string{
+						"kind":          "test",
+						"sloth_service": "test-svc",
+						"sloth_slo":     "test-name",
+						"sloth_id":      "test",
+					},
+				},
+				{
+					Record: "slo:period_burn_rate:ratio",
+					Expr: `slo:sli_error:ratio_rate30d{kind="test", sloth_id="test", sloth_service="test-svc", sloth_slo="test-name"}
+/ on(kind, namespace, sloth_id, sloth_service, sloth_slo) group_left
+slo:error_budget:ratio{kind="test", sloth_id="test", sloth_service="test-svc", sloth_slo="test-name"}
+`,
+					Labels: map[string]string{
+						"kind":          "test",
+						"sloth_service": "test-svc",
+						"sloth_slo":     "test-name",
+						"sloth_id":      "test",
+					},
+				},
+				{
+					Record: "slo:period_error_budget_remaining:ratio",
+					Expr:   `1 - slo:period_burn_rate:ratio{kind="test", sloth_id="test", sloth_service="test-svc", sloth_slo="test-name"}`,
+					Labels: map[string]string{
+						"kind":          "test",
+						"sloth_service": "test-svc",
+						"sloth_slo":     "test-name",
+						"sloth_id":      "test",
+					},
+				},
+				{
+					Record: "sloth_slo_info",
+					Expr: `vector(1) * group(slo:current_burn_rate:ratio{kind="test", sloth_id="test", sloth_service="test-svc", sloth_slo="test-name"})
+by (namespace)`,
+					Labels: map[string]string{
+						"kind":            "test",
+						"sloth_service":   "test-svc",
+						"sloth_slo":       "test-name",
+						"sloth_id":        "test",
+						"sloth_version":   "test-ver",
+						"sloth_mode":      "test",
+						"sloth_spec":      "test/v1",
+						"sloth_objective": "99.9",
+					},
+				},
+				{
+					Record: "slo:objective:ratio",
+					Expr: `vector(0.9990000000000001) * group(sloth_slo_info{kind="test", sloth_id="test", sloth_service="test-svc", sloth_slo="test-name"})
+by (namespace)`,
+					Labels: map[string]string{
+						"kind":          "test",
+						"sloth_service": "test-svc",
+						"sloth_slo":     "test-name",
+						"sloth_id":      "test",
+					},
+				},
+				{
+					Record: "slo:error_budget:ratio",
+					Expr: `vector(1-0.9990000000000001) * group(sloth_slo_info{kind="test", sloth_id="test", sloth_service="test-svc", sloth_slo="test-name"})
+by (namespace)`,
+					Labels: map[string]string{
+						"kind":          "test",
+						"sloth_service": "test-svc",
+						"sloth_slo":     "test-name",
+						"sloth_id":      "test",
+					},
+				},
+				{
+					Record: "slo:time_period:days",
+					Expr: `vector(30) * group(sloth_slo_info{kind="test", sloth_id="test", sloth_service="test-svc", sloth_slo="test-name"})
+by (namespace)`,
+					Labels: map[string]string{
+						"kind":          "test",
+						"sloth_service": "test-svc",
+						"sloth_slo":     "test-name",
+						"sloth_id":      "test",
 					},
 				},
 			},


### PR DESCRIPTION
When groupByLabels is configured, scalar rules (objective, error_budget, time_period) now carry the extra label dimension by joining against sloth_slo_info via a group_left expression, and sloth_slo_info itself joins against slo:current_burn_rate:ratio. Updates test expectations to match the new rule order and group_left expr suffixes.

Co-Authored-By: Claude noreply@anthropic.com